### PR TITLE
Josh branch

### DIFF
--- a/UVsim.h
+++ b/UVsim.h
@@ -3,8 +3,8 @@
 class UVSim
 {
     public:
-        UVSim() = default;
-        ~UVSim() = default;
+        UVSim();
+        ~UVSim();
 
         //METHODS
 

--- a/UVsim.h
+++ b/UVsim.h
@@ -1,21 +1,23 @@
+#include "dataType.h"
+
 class UVSim
 {
     public:
-        UVSim();
-        ~UVSim();
+        UVSim() = default;
+        ~UVSim() = default;
 
         //METHODS
 
     protected:
         //Initialize the operations
         //Memory allocation of 100 all initialized to 0
-        int mainMemory[100] = { };
+        word mainMemory[100] = { };
 
-        //register
-        int simRegister = 0;        //TODO: WHAT IS THE REGISTER!?=-=-=-=-=-=-======================================================
+        //program counter
+        word pc = word(0);       //Holds the index for the next instruction to be executed from mainMemory
 
         //accumulator
-        int accumulator = 0;        //This will hold data that will be used in some way
+        word accumulator = word(0);        //This will hold data that will be used in some way
 
         //Vocam Definitions with values
             //i/o

--- a/dataType.h
+++ b/dataType.h
@@ -9,7 +9,7 @@ public:
 	
 
 	bool writeWord(int data); // Changes the value of the word to data provided. Returns true if the written value was within bounds. Returns false if the written value was out of bounds, and sets the data to max (if over) or min (if under) value
-	int readWord();
+	int readWord(); // Returns the integer value contained within word. Will be within the bounds of [MIN_WORD_VALUE, MAX_WORD_VALUE] inclusive
 
 protected:
 	int data;

--- a/dataType.h
+++ b/dataType.h
@@ -1,1 +1,40 @@
-// this is a comment
+constexpr int MAX_WORD_VALUE = 9999;
+constexpr int MIN_WORD_VALUE = -9999;
+
+struct word {
+public:
+	word() : data(0) {}
+	word(int newData) : data(newData) {}
+	~word() = default;
+	
+
+	bool writeWord(int data); // Changes the value of the word to data provided. Returns true if the written value was within bounds. Returns false if the written value was out of bounds, and sets the data to max (if over) or min (if under) value
+	int readWord();
+
+protected:
+	int data;
+
+	word& operator=(const int&) = delete; // Disables the assignment operator for int. Whenever assigning an int value to a word, do it through the writeWord() method
+};
+
+
+bool word::writeWord(int newData) {
+
+	if (newData > MAX_WORD_VALUE) 
+	{
+		this->data = MAX_WORD_VALUE;
+		return false;
+	}
+	else if (newData < MIN_WORD_VALUE) 
+	{
+		this->data = MIN_WORD_VALUE;
+		return false;
+	}
+
+	this->data = newData;
+	return true;
+}
+
+int word::readWord() {
+	return this->data;
+}


### PR DESCRIPTION
Created the dataType.h file. 
----------------------------
- I ended up creating the readWord() and writeWord() functions as methods of the word datatype in order for the word's data to be private
- writeWord() returns bool which is true if the written word was within bounds, and false if it was out of bounds. Read function or it's comment if you need more clarity
- I also disabled the assignment operator for ints so that when changing the data within a word you have to use the writeWord() function
- Added the constants of MAX_WORD_VALUE and MIN_WORD_VALUE


Edited the UVsim.h file
-----------------------
- Changed the "register" to "pc" for program counter since we need a program counter and the accumulator acts as the register (I thought Wyatt already did this before when we were in a meeting, but it looks like that change didn't end up in this repository). I also changed its type from int to word
- Changed the mainMemory[] array from int type to word type
- Changed the accumulator from int type to word type

The way I set up the word dataType isn't necessarily final, and can be changed if anybody else has improvements or thinks it should be set up differently